### PR TITLE
Apply chagnes in search characters

### DIFF
--- a/Utilities/Contract.yaml
+++ b/Utilities/Contract.yaml
@@ -26,6 +26,24 @@ paths:
                 maxItems: 100
                 items:
                   $ref: '#/components/schemas/CharacterPayloadWithRelations'
+              examples:
+                page:
+                  summary: One page with relations and facts
+                  value:
+                    - id: "0b6c1f8a-9c2e-4a18-93a5-3a5e3a5e3a5e"
+                      name: "Gandalf"
+                      knowCharacters:
+                        - characterId: "11111111-1111-4111-8111-111111111111"
+                          description: "Met in the Shire"
+                          isStrongRelation: true
+                      facts:
+                        - id: "33333333-3333-4333-8333-333333333333"
+                          title: "Wizard of the Secret Fire"
+                          content: "Wielder of Narya, one of the three Elven rings."
+                    - id: "11111111-1111-4111-8111-111111111111"
+                      name: "Frodo"
+                      knowCharacters: [ ]
+                      facts: [ ]
         '400':
           $ref: '#/components/responses/BadRequest'
     post:
@@ -536,7 +554,7 @@ components:
     CharacterPayloadWithRelations:
       type: object
       title: CharacterPayloadWithRelations
-      required: [ id, name, knowCharacters ]
+      required: [ id, name, knowCharacters, facts ]
       properties:
         id:
           type: string
@@ -551,6 +569,29 @@ components:
           maxItems: 50
           items:
             $ref: '#/components/schemas/KnowCharacterRelationPayload'
+        facts:
+          type: array
+          description: Facts connected to the character via HAS_FACT
+          minItems: 0
+          maxItems: 50
+          items:
+            $ref: '#/components/schemas/CharacterFactPayload'
+    CharacterFactPayload:
+      type: object
+      title: CharacterFactPayload
+      required: [ id, title, content ]
+      properties:
+        id:
+          type: string
+          format: uuid
+        title:
+          type: string
+          minLength: 1
+          maxLength: 100
+        content:
+          type: string
+          minLength: 1
+          maxLength: 512
     KnowCharacterRelationPayload:
       type: object
       title: KnowCharacterRelationPayload

--- a/src/LoreWeave.Application/Models/CharacterFactPayload.cs
+++ b/src/LoreWeave.Application/Models/CharacterFactPayload.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace LoreWeave.Application.Models;
+
+public record CharacterFactPayload(
+    [property: JsonPropertyName("id")]
+    Guid Id,
+    [StringLength(100, MinimumLength = 1, ErrorMessage = "Value for {0} must be between {1} and {2} characters.")]
+    [property: JsonPropertyName("title")]
+    string Title,
+    [StringLength(512, MinimumLength = 1, ErrorMessage = "Value for {0} must be between {1} and {2} characters.")]
+    [property: JsonPropertyName("content")]
+    string Content);

--- a/src/LoreWeave.Application/Models/CharacterPayloadWithRelations.cs
+++ b/src/LoreWeave.Application/Models/CharacterPayloadWithRelations.cs
@@ -10,4 +10,6 @@ public record CharacterPayloadWithRelations(
     [property: JsonPropertyName("name")]
     string Name,
     [property: JsonPropertyName("knowCharacters")]
-    IReadOnlyCollection<KnowCharacterRelationPayload> KnowCharacters);
+    IReadOnlyCollection<KnowCharacterRelationPayload> KnowCharacters,
+    [property: JsonPropertyName("facts")]
+    IReadOnlyCollection<CharacterFactPayload> Facts);

--- a/src/LoreWeave.Application/Queries/Characters/QueryHandlers/GetCharacterPageQueryHandler.cs
+++ b/src/LoreWeave.Application/Queries/Characters/QueryHandlers/GetCharacterPageQueryHandler.cs
@@ -60,6 +60,13 @@ public class GetCharacterPageQueryHandler
                             relation.Description,
                             relation.IsStrongRelation))
                         .ToList()
+                        .AsReadOnly(),
+                    x.Facts
+                        .Select(fact => new CharacterFactPayload(
+                            fact.Id,
+                            fact.Title,
+                            fact.Content))
+                        .ToList()
                         .AsReadOnly()))
                 .ToList()
                 .AsReadOnly();

--- a/src/LoreWeave.Domain/Models/CharacterWithKnowRelation.cs
+++ b/src/LoreWeave.Domain/Models/CharacterWithKnowRelation.cs
@@ -3,4 +3,5 @@ namespace LoreWeave.Domain.Models;
 public sealed record CharacterWithKnowRelation(
     Guid Id,
     string Name,
-    IReadOnlyCollection<KnowRelationDetail> KnowRelations);
+    IReadOnlyCollection<KnowRelationDetail> KnowRelations,
+    IReadOnlyCollection<FactDetail> Facts);

--- a/src/LoreWeave.Domain/Models/FactDetail.cs
+++ b/src/LoreWeave.Domain/Models/FactDetail.cs
@@ -1,0 +1,6 @@
+namespace LoreWeave.Domain.Models;
+
+public sealed record FactDetail(
+    Guid Id,
+    string Title,
+    string Content);

--- a/src/LoreWeave.Infrastructure/Repositories/Characters/CharacterRepository.cs
+++ b/src/LoreWeave.Infrastructure/Repositories/Characters/CharacterRepository.cs
@@ -119,6 +119,8 @@ public class CharacterRepository : IExistsCharacter, ICharacterReader, ICharacte
             .AppendLine("WHERE $NameFilter = '' OR toLower(ch.Name) CONTAINS toLower($NameFilter)")
             .AppendLine("OPTIONAL MATCH (ch)-[r:KNOWS]->(toCh:Character)")
             .AppendLine("WITH ch, collect(CASE WHEN toCh IS NULL THEN null ELSE {Id: toCh.Id, Description: r.Description, IsStrong: r.IsStrong} END) AS KnowRelations")
+            .AppendLine("OPTIONAL MATCH (ch)-[:HAS_FACT]->(f:Fact)")
+            .AppendLine("WITH ch, KnowRelations, collect(CASE WHEN f IS NULL THEN null ELSE {Id: f.Id, Title: f.Title, Content: f.Content} END) AS Facts")
             .AppendLine("ORDER BY")
             .AppendLine("CASE WHEN $SortType = 'Id' AND $SortOrder = 'Asc' THEN ch.Id END ASC,")
             .AppendLine("CASE WHEN $SortType = 'Id' AND $SortOrder = 'Desc' THEN ch.Id END DESC,")
@@ -126,7 +128,7 @@ public class CharacterRepository : IExistsCharacter, ICharacterReader, ICharacte
             .AppendLine("CASE WHEN $SortType = 'Name' AND $SortOrder = 'Desc' THEN ch.Name END DESC")
             .AppendLine("SKIP $Skip")
             .AppendLine("LIMIT $Limit")
-            .AppendLine("RETURN ch.Id AS Id, ch.Name AS Name, KnowRelations");
+            .AppendLine("RETURN ch.Id AS Id, ch.Name AS Name, KnowRelations, Facts");
 
         var query = new Query(queryStringBuilder.ToString(), new
         {

--- a/src/LoreWeave.Infrastructure/Repositories/Extensions/RecordExtensions.cs
+++ b/src/LoreWeave.Infrastructure/Repositories/Extensions/RecordExtensions.cs
@@ -33,6 +33,14 @@ public static class RecordExtensions
                     relation["Description"].As<string>(),
                     relation["IsStrong"].As<bool>()))
                 .ToList()
+                .AsReadOnly(),
+            record["Facts"]
+                .As<List<IReadOnlyDictionary<string, object>>>()
+                .Select(fact => new FactDetail(
+                    fact["Id"].As<string>().DatabaseIdToGuid(),
+                    fact["Title"].As<string>(),
+                    fact["Content"].As<string>()))
+                .ToList()
                 .AsReadOnly());
 
         return character;

--- a/test/LoreWeave.Api.Integration.Test/Endpoints/Characters/GetCharacterPageEndpointTest.cs
+++ b/test/LoreWeave.Api.Integration.Test/Endpoints/Characters/GetCharacterPageEndpointTest.cs
@@ -18,6 +18,8 @@ public class GetCharacterPageEndpointTest : IntegrationTestBase
 
     public const string KnowEndpoint = "/v1/characters/knows";
 
+    private static string FactEndpoint(Guid characterId) => $"{Endpoint}/{characterId}/facts";
+
     [Theory]
     [InlineData(1, 10, "Name", "Asc")]
     [InlineData(1, 10, "Name", "Desc")]
@@ -80,6 +82,20 @@ public class GetCharacterPageEndpointTest : IntegrationTestBase
             await Client.PostAsJsonAsync(KnowEndpoint, createRelationRequest, CancellationToken.None);
         }
 
+        var factIds = new List<Guid>();
+        foreach (var characterId in characterIds)
+        {
+            var createFactRequest = new
+            {
+                Title = "TestFact",
+                Content = "TestContent"
+            };
+
+            var factResponse = await Client.PutAsJsonAsync(
+                FactEndpoint(characterId), createFactRequest, CancellationToken.None);
+            factIds.Add(await factResponse.Content.ReadFromJsonAsync<Guid>());
+        }
+
         var endpoint =
             $"{Endpoint}?pageNumber={pageNumber}&pageSize={pageSize}&sortType={sortType}&sortOrder={sortOrder}";
 
@@ -98,6 +114,61 @@ public class GetCharacterPageEndpointTest : IntegrationTestBase
         list.ShouldAllBe(c => c.KnowCharacters.First().Description == "Test");
         list.ShouldAllBe(c => c.KnowCharacters.First().IsStrongRelation);
         list.All(c => characterIds.Contains(c.KnowCharacters.First().CharacterId)).ShouldBeTrue();
+        list.ShouldAllBe(c => c.Facts.Count == 1);
+        list.ShouldAllBe(c => c.Facts.First().Title == "TestFact");
+        list.ShouldAllBe(c => c.Facts.First().Content == "TestContent");
+        list.All(c => factIds.Contains(c.Facts.First().Id)).ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task GetCharacterPage_WithFacts_ReturnsConnectedFactsPerCharacter()
+    {
+        // Arrange
+        await _neo4JContainerRunner.ResetAsync();
+
+        var withFactsResponse = await Client.PostAsJsonAsync(
+            Endpoint, new { Name = "CharacterWithFacts" }, CancellationToken.None);
+        var withFactsId = await withFactsResponse.Content.ReadFromJsonAsync<Guid>();
+
+        var withoutFactsResponse = await Client.PostAsJsonAsync(
+            Endpoint, new { Name = "CharacterWithoutFacts" }, CancellationToken.None);
+        var withoutFactsId = await withoutFactsResponse.Content.ReadFromJsonAsync<Guid>();
+
+        var expectedFacts = new[]
+        {
+            new { Title = "FactA", Content = "ContentA" },
+            new { Title = "FactB", Content = "ContentB" }
+        };
+
+        var factIds = new List<Guid>();
+        foreach (var fact in expectedFacts)
+        {
+            var factResponse = await Client.PutAsJsonAsync(
+                FactEndpoint(withFactsId), fact, CancellationToken.None);
+            factIds.Add(await factResponse.Content.ReadFromJsonAsync<Guid>());
+        }
+
+        var endpoint = $"{Endpoint}?pageNumber=1&pageSize=10&sortType=Name&sortOrder=Asc";
+
+        // Act
+        var response = await Client.GetAsync(endpoint);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var content = await response.Content.ReadFromJsonAsync<IEnumerable<CharacterPayloadWithRelations>>();
+        var list = content!.ToList();
+
+        list.Count.ShouldBe(2);
+
+        var withFacts = list.Single(c => c.Id == withFactsId);
+        withFacts.Facts.Count.ShouldBe(2);
+        withFacts.Facts.Select(f => f.Id).ShouldBe(factIds, ignoreOrder: true);
+        withFacts.Facts.Select(f => f.Title).ShouldBe(expectedFacts.Select(f => f.Title), ignoreOrder: true);
+        withFacts.Facts.Select(f => f.Content).ShouldBe(expectedFacts.Select(f => f.Content), ignoreOrder: true);
+
+        var withoutFacts = list.Single(c => c.Id == withoutFactsId);
+        withoutFacts.Facts.ShouldBeEmpty();
     }
 
 

--- a/test/LoreWeave.Application.Test/Queries/Characters/QueryHandlers/GetCharacterPageQueryHandlerTest.cs
+++ b/test/LoreWeave.Application.Test/Queries/Characters/QueryHandlers/GetCharacterPageQueryHandlerTest.cs
@@ -42,14 +42,21 @@ public class GetCharacterPageQueryHandlerTest
         // Arrange
         var query = new GetCharacterPageQuery(1, 10, "Name", "Asc", null);
         var knownCharacterId = Guid.CreateVersion7();
+        var factId = Guid.CreateVersion7();
         var characters = new List<CharacterWithKnowRelation>
         {
             new(Guid.CreateVersion7(), "CharacterA",
                 new List<KnowRelationDetail>
                 {
                     new(knownCharacterId, "Childhood friends", true)
+                }.AsReadOnly(),
+                new List<FactDetail>
+                {
+                    new(factId, "Bearer of the One Ring", "Carried the One Ring to Mount Doom.")
                 }.AsReadOnly()),
-            new(Guid.CreateVersion7(), "CharacterB", new List<KnowRelationDetail>().AsReadOnly())
+            new(Guid.CreateVersion7(), "CharacterB",
+                new List<KnowRelationDetail>().AsReadOnly(),
+                new List<FactDetail>().AsReadOnly())
         }.AsReadOnly();
 
         _characterReader
@@ -71,7 +78,49 @@ public class GetCharacterPageQueryHandlerTest
         relation.Description.ShouldBe("Childhood friends", "Relation description should match");
         relation.IsStrongRelation.ShouldBeTrue("Relation should be marked as strong");
 
+        result.Value.First().Facts.Count.ShouldBe(1, "First character should have 1 connected fact");
+        var fact = result.Value.First().Facts.First();
+        fact.Id.ShouldBe(factId, "Fact id should match the connected fact");
+        fact.Title.ShouldBe("Bearer of the One Ring", "Fact title should match");
+        fact.Content.ShouldBe("Carried the One Ring to Mount Doom.", "Fact content should match");
+
         result.Value.Last().KnowCharacters.ShouldBeEmpty("Second character should have no relations");
+        result.Value.Last().Facts.ShouldBeEmpty("Second character should have no facts");
+    }
+
+    [Fact]
+    [Trait(Constants.TraitName, Constants.TestTitle)]
+    public async Task InvokeAsync_WhenCharacterHasMultipleFacts_ReturnsAllFacts()
+    {
+        // Arrange
+        var query = new GetCharacterPageQuery(1, 10, "Name", "Asc", null);
+        var facts = new List<FactDetail>
+        {
+            new(Guid.CreateVersion7(), "FactA", "ContentA"),
+            new(Guid.CreateVersion7(), "FactB", "ContentB")
+        }.AsReadOnly();
+        var characters = new List<CharacterWithKnowRelation>
+        {
+            new(Guid.CreateVersion7(), "CharacterA",
+                new List<KnowRelationDetail>().AsReadOnly(),
+                facts)
+        }.AsReadOnly();
+
+        _characterReader
+            .GetPageAsync(Arg.Any<ITransaction>(), Arg.Any<GetCharacterPage>(), Arg.Any<CharacterSearchFilter>())
+            .Returns(characters);
+
+        // Act
+        var result = await _sut.InvokeAsync(query);
+
+        // Assert
+        result.IsSuccess.ShouldBeTrue("Query should succeed when characters are found");
+        var payload = result.Value.Single();
+        payload.Facts.Count.ShouldBe(2, "Character should have both connected facts");
+        payload.Facts.Select(f => f.Id).ShouldBe(facts.Select(f => f.Id), "Fact ids should match");
+        payload.Facts.Select(f => f.Title).ShouldBe(["FactA", "FactB"], "Fact titles should match");
+        payload.Facts.Select(f => f.Content).ShouldBe(["ContentA", "ContentB"], "Fact contents should match");
+        payload.KnowCharacters.ShouldBeEmpty("Character should have no relations");
     }
 
     [Fact]


### PR DESCRIPTION
What changed                                                                                                                
                                                                                                                              
  Character search (GET /v1/characters) now returns the facts connected to each character via HAS_FACT, following the same    
  pattern the KNOWS relations already used (collected in Cypher, carried through a Domain model, mapped to a payload in the   
  query handler).                                                                                                             
                                                                                                                              
  Contract first (Utilities/Contract.yaml, per the API-first workflow):                                                       
  - CharacterPayloadWithRelations gained a required facts array (bounds 0..50) of a new CharacterFactPayload schema (id uuid, 
  title 1–100, content 1–512 — matching FactDto), plus a response example.                            
                                                                                                                              
  Domain:                                                                                                                     
  - New Models/FactDetail.cs (Id, Title, Content).                                                                            
  - CharacterWithKnowRelation gained a Facts collection.                                                                      
                                                                                                                              
  Infrastructure (CharacterRepository.GetPageAsync):                                                                          
  - Added a second OPTIONAL MATCH (ch)-[:HAS_FACT]->(f:Fact) with its own collect(...) after the KNOWS collect, so the two    
  collections don't cross-product; Facts is returned alongside KnowRelations and mapped in                                    
  RecordExtensions.ToCharacterWithKnowRelation.        
  
  Application:                                                                                                                
  - New CharacterFactPayload record (with JsonPropertyName/StringLength matching the contract), facts added to                
  CharacterPayloadWithRelations, and mapping added in GetCharacterPageQueryHandler.                                           
                                                                                                                              
  Tests:                                                                                                                      
  - Unit (GetCharacterPageQueryHandlerTest): the existing page test now also asserts a character's fact and that a character  
  without facts returns an empty collection; new test InvokeAsync_WhenCharacterHasMultipleFacts_ReturnsAllFacts.              
  - Integration (GetCharacterPageEndpointTest): the main page test now creates one fact per character and asserts they come   
  back; new test GetCharacterPage_WithFacts_ReturnsConnectedFactsPerCharacter covers a character with two facts and one with  
  none.                                                            